### PR TITLE
bug fix for translation of plural hours in Snooze popups #131

### DIFF
--- a/src/services/AlarmService.as
+++ b/src/services/AlarmService.as
@@ -348,8 +348,8 @@ package services
 			
 			for (var cntr:int = 0;cntr < snoozeValueMinutes.length;cntr++) {
 				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("minutes", ModelLocator.resourceManagerInstance.getString("alarmservice","minutes"));
-				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("hour", ModelLocator.resourceManagerInstance.getString("alarmservice","hour"));
 				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("hours", ModelLocator.resourceManagerInstance.getString("alarmservice","hours"));
+				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("hour", ModelLocator.resourceManagerInstance.getString("alarmservice","hour"));
 				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("day", ModelLocator.resourceManagerInstance.getString("alarmservice","day"));
 				snoozeValueStrings[cntr] = (snoozeValueStrings[cntr] as String).replace("week", ModelLocator.resourceManagerInstance.getString("alarmservice","week"));
 			}


### PR DESCRIPTION
I didn't have time to check this out. That is why I didn't check it in directly into master.

The problem was that hour was replaced/translated before hours. All other occurences with replacement of hours and hour were implemented correctly.

There was a warning in GitHub that line ending are not consistent and that during the save process it will correct it. I hope that GitHub handled it correctly.